### PR TITLE
Add some VisualStudio specific entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,28 @@
-bin/
-obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio 2015 cache/options directory
+.vs/
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates


### PR DESCRIPTION
Really nice library for PostalServer. I see you use Rider, but when opening this solution in VS I got a lot of artifact files that git wanted to add, so I added them to .gitignore. Getting support from Visualstudio users will be easier with this in place.