### PR TITLE
Remove old-style package reference from csproj. 

### DIFF
--- a/PostalApiClient/PostalApiClient.csproj
+++ b/PostalApiClient/PostalApiClient.csproj
@@ -32,12 +32,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="Microsoft.Extensions.Configuration.Abstractions">
-        <HintPath>C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\7.0.5\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
-      </Reference>
-    </ItemGroup>
-
-    <ItemGroup>
       <Compile Update="v1\Sends\Models\PostalMessageAttachment.cs">
         <DependentUpon>PostalMessage.cs</DependentUpon>
       </Compile>


### PR DESCRIPTION
I noticed an old style package reference in the csproj. The reference is not needed since it is taken in as a transient dependency through Microsoft.Extensions.Options.ConfigurationExtensions.